### PR TITLE
Write moniter program pid and write it as integer instead of bytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+*.pid


### PR DESCRIPTION
Keeping pid file consistent with other unix commands